### PR TITLE
sirono

### DIFF
--- a/.idea/sirono-common.iml
+++ b/.idea/sirono-common.iml
@@ -3,17 +3,16 @@
   <component name="FacetManager">
     <facet type="IlluminatedCloud" name="Illuminated Cloud">
       <configuration>
-        <option name="connectionName" value="sirono_local" />
+        <option name="connectionName" value="sirono-common" />
         <option name="moduleContents">
           <ModuleContents>
             <option name="contentSelectionType" value="PACKAGE_XML" />
             <option name="manifest">
               <Manifest />
             </option>
-            <option name="packageXmlRelativePath" value="sirono-common/src/package.xml" />
+            <option name="packageXmlRelativePath" value="src/package.xml" />
           </ModuleContents>
         </option>
-        <option name="packageName" value="Sirono Common" />
       </configuration>
     </facet>
   </component>
@@ -23,7 +22,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/test-src" isTestSource="true" />
     </content>
-    <orderEntry type="jdk" jdkName="IlluminatedCloud (sirono-salesforce/sirono_local)" jdkType="IlluminatedCloud" />
+    <orderEntry type="jdk" jdkName="IlluminatedCloud (sirono-common/sirono-common)" jdkType="IlluminatedCloud" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/.idea/sirono-common.iml
+++ b/.idea/sirono-common.iml
@@ -3,14 +3,14 @@
   <component name="FacetManager">
     <facet type="IlluminatedCloud" name="Illuminated Cloud">
       <configuration>
-        <option name="connectionName" value="sirono-common" />
+        <option name="connectionName" value="sirono_local" />
         <option name="moduleContents">
           <ModuleContents>
             <option name="contentSelectionType" value="PACKAGE_XML" />
             <option name="manifest">
               <Manifest />
             </option>
-            <option name="packageXmlRelativePath" value="src/package.xml" />
+            <option name="packageXmlRelativePath" value="sirono-common/src/package.xml" />
           </ModuleContents>
         </option>
       </configuration>
@@ -22,7 +22,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/test-src" isTestSource="true" />
     </content>
-    <orderEntry type="jdk" jdkName="IlluminatedCloud (sirono-common/sirono-common)" jdkType="IlluminatedCloud" />
+    <orderEntry type="jdk" jdkName="IlluminatedCloud (sirono-salesforce/sirono_local)" jdkType="IlluminatedCloud" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/.idea/sirono-common.iml
+++ b/.idea/sirono-common.iml
@@ -13,6 +13,7 @@
             <option name="packageXmlRelativePath" value="sirono-common/src/package.xml" />
           </ModuleContents>
         </option>
+        <option name="packageName" value="Sirono Common" />
       </configuration>
     </facet>
   </component>

--- a/src/classes/PicklistEnum.cls
+++ b/src/classes/PicklistEnum.cls
@@ -17,12 +17,12 @@
 /**
  * Base class for enum-like classes which provide Apex compile-time constants for picklist field values.
  */
-global with sharing abstract class PicklistEnum {
+public with sharing abstract class PicklistEnum {
 
     /**
      * Each entry corresponds to a single distinct value for the enum's picklist field.
      */
-    global with sharing class Entry {
+    public with sharing virtual class Entry {
         private String value { get; set; }
         private String label { get; set; }
         private Boolean active { get; set; }
@@ -34,7 +34,7 @@ global with sharing abstract class PicklistEnum {
          * @param picklistEnum the parent picklist enum
          * @param picklistEntry the picklist field entry
          */
-        private Entry(PicklistEnum picklistEnum, Schema.PicklistEntry picklistEntry) {
+        protected Entry(PicklistEnum picklistEnum, Schema.PicklistEntry picklistEntry) {
             this.value = picklistEntry.getValue();
             this.label = picklistEntry.getLabel();
             this.active = picklistEntry.isActive();
@@ -61,7 +61,7 @@ global with sharing abstract class PicklistEnum {
          *
          * @return the enum entry's string value
          */
-        global String value() {
+        public virtual String value() {
             return value;
         }
 
@@ -70,7 +70,7 @@ global with sharing abstract class PicklistEnum {
          *
          * @return the enum entry's label
          */
-        global String label() {
+        public virtual String label() {
             return label;
         }
 
@@ -79,7 +79,7 @@ global with sharing abstract class PicklistEnum {
          *
          * @return whether the enum entry is active
          */
-        global Boolean isActive() {
+        public virtual Boolean isActive() {
             return active;
         }
 
@@ -88,7 +88,7 @@ global with sharing abstract class PicklistEnum {
          *
          * @return whether the enum entry is the enum's default value
          */
-        global Boolean isDefaultValue() {
+        public virtual Boolean isDefaultValue() {
             return defaultValue;
         }
 
@@ -99,7 +99,7 @@ global with sharing abstract class PicklistEnum {
          *
          * @return <code>true</code> if the specified value matches this entry; otherwise <code>false</code>
          */
-        global Boolean equalTo(String testValue) {
+        public virtual Boolean equalTo(String testValue) {
             return value.equalsIgnoreCase(testValue);
         }
 
@@ -110,7 +110,7 @@ global with sharing abstract class PicklistEnum {
          *
          * @return <code>true</code> if the specified value is different from this entry; otherwise <code>false</code>
          */
-        global Boolean notEqualTo(String testValue) {
+        public virtual Boolean notEqualTo(String testValue) {
             return !equalTo(testValue);
         }
 
@@ -119,7 +119,7 @@ global with sharing abstract class PicklistEnum {
          *
          * @return the enum entry's string value
          */
-        global override String toString() {
+        public override String toString() {
             return value;
         }
     }
@@ -150,9 +150,20 @@ global with sharing abstract class PicklistEnum {
     private void createEntries() {
         Schema.DescribeFieldResult picklistDescribe = picklistField.getDescribe();
         for (Schema.PicklistEntry picklistEntry : picklistDescribe.getPicklistValues()) {
-            Entry entry = new Entry(this, picklistEntry);
+            Entry entry = createEntry(picklistEntry);
             entriesByValue.put(entry.value, entry);
         }
+    }
+
+    /**
+     * Creates an picklist enum entry for the specified picklist entry.
+     *
+     * @param picklistEntry the picklist entry for which a picklist enum entry should be created
+     *
+     * @return the picklist enum entry
+     */
+    protected virtual Entry createEntry(PicklistEntry picklistEntry) {
+        return new Entry(this, picklistEntry);
     }
 
     /**
@@ -162,7 +173,7 @@ global with sharing abstract class PicklistEnum {
      *
      * @return the corresponding entry or <code>null</code> if no entry exists for the specified value
      */
-    global Entry getEntry(String value) {
+    public Entry getEntry(String value) {
         return entriesByValue.get(value);
     }
 
@@ -171,7 +182,7 @@ global with sharing abstract class PicklistEnum {
      *
      * @return all entries for this picklist enum
      */
-    global Entry[] getEntries() {
+    public Entry[] getEntries() {
         return entries;
     }
 }

--- a/src/classes/PicklistEnum.cls
+++ b/src/classes/PicklistEnum.cls
@@ -156,7 +156,7 @@ public with sharing abstract class PicklistEnum {
     }
 
     /**
-     * Creates an picklist enum entry for the specified picklist entry.
+     * Creates a picklist enum entry for the specified picklist entry.
      *
      * @param picklistEntry the picklist entry for which a picklist enum entry should be created
      *

--- a/src/classes/PicklistEnum.cls
+++ b/src/classes/PicklistEnum.cls
@@ -17,12 +17,12 @@
 /**
  * Base class for enum-like classes which provide Apex compile-time constants for picklist field values.
  */
-public with sharing abstract class PicklistEnum {
+global with sharing abstract class PicklistEnum {
 
     /**
      * Each entry corresponds to a single distinct value for the enum's picklist field.
      */
-    public with sharing class Entry {
+    global with sharing class Entry {
         private String value { get; set; }
         private String label { get; set; }
         private Boolean active { get; set; }
@@ -61,7 +61,7 @@ public with sharing abstract class PicklistEnum {
          *
          * @return the enum entry's string value
          */
-        public String value() {
+        global String value() {
             return value;
         }
 
@@ -70,7 +70,7 @@ public with sharing abstract class PicklistEnum {
          *
          * @return the enum entry's label
          */
-        public String label() {
+        global String label() {
             return label;
         }
 
@@ -79,7 +79,7 @@ public with sharing abstract class PicklistEnum {
          *
          * @return whether the enum entry is active
          */
-        public Boolean isActive() {
+        global Boolean isActive() {
             return active;
         }
 
@@ -88,7 +88,7 @@ public with sharing abstract class PicklistEnum {
          *
          * @return whether the enum entry is the enum's default value
          */
-        public Boolean isDefaultValue() {
+        global Boolean isDefaultValue() {
             return defaultValue;
         }
 
@@ -99,7 +99,7 @@ public with sharing abstract class PicklistEnum {
          *
          * @return <code>true</code> if the specified value matches this entry; otherwise <code>false</code>
          */
-        public Boolean equalTo(String testValue) {
+        global Boolean equalTo(String testValue) {
             return value.equalsIgnoreCase(testValue);
         }
 
@@ -110,7 +110,7 @@ public with sharing abstract class PicklistEnum {
          *
          * @return <code>true</code> if the specified value is different from this entry; otherwise <code>false</code>
          */
-        public Boolean notEqualTo(String testValue) {
+        global Boolean notEqualTo(String testValue) {
             return !equalTo(testValue);
         }
 
@@ -119,7 +119,7 @@ public with sharing abstract class PicklistEnum {
          *
          * @return the enum entry's string value
          */
-        public override String toString() {
+        global override String toString() {
             return value;
         }
     }
@@ -162,7 +162,7 @@ public with sharing abstract class PicklistEnum {
      *
      * @return the corresponding entry or <code>null</code> if no entry exists for the specified value
      */
-    public Entry getEntry(String value) {
+    global Entry getEntry(String value) {
         return entriesByValue.get(value);
     }
 
@@ -171,7 +171,7 @@ public with sharing abstract class PicklistEnum {
      *
      * @return all entries for this picklist enum
      */
-    public Entry[] getEntries() {
+    global Entry[] getEntries() {
         return entries;
     }
 }

--- a/src/classes/TypeSafeEnum.cls
+++ b/src/classes/TypeSafeEnum.cls
@@ -52,7 +52,7 @@ public with sharing abstract class TypeSafeEnum {
      *
      * @return the enum entry's string value
      */
-    public String value() {
+    public virtual String value() {
         return value;
     }
 
@@ -61,7 +61,7 @@ public with sharing abstract class TypeSafeEnum {
      *
      * @return the enum entry's ordinal
      */
-    public Integer ordinal() {
+    public virtual Integer ordinal() {
         return ordinal;
     }
 
@@ -72,7 +72,7 @@ public with sharing abstract class TypeSafeEnum {
      *
      * @return <code>true</code> if the specified value matches this entry; otherwise <code>false</code>
      */
-    public Boolean equalTo(String testValue) {
+    public virtual Boolean equalTo(String testValue) {
         return value().equalsIgnoreCase(testValue);
     }
 
@@ -83,7 +83,7 @@ public with sharing abstract class TypeSafeEnum {
      *
      * @return <code>true</code> if the specified value is different from this entry; otherwise <code>false</code>
      */
-    public Boolean notEqualTo(String testValue) {
+    public virtual Boolean notEqualTo(String testValue) {
         return !equalTo(testValue);
     }
 

--- a/test-src/classes/CollectionUtilTest.cls
+++ b/test-src/classes/CollectionUtilTest.cls
@@ -370,48 +370,48 @@ private class CollectionUtilTest {
 
     @IsTest
     static void testGetIds() {
-        List<Account> accounts = new List<Account>();
+        List<Contact> contacts = new List<Contact>();
         for (Integer i = 0; i < 5; i++) {
-            accounts.add(new Account(
-                Name = 'Account ' + (i + 1),
-                External_Account_Name__c = 'Account ' + (i + 1)
+            contacts.add(new Contact(
+                FirstName = 'Test',
+                LastName = 'User ' + (i + 1)
             ));
         }
-        insert accounts;
+        insert contacts;
 
-        List<Id> accountIds = CollectionUtil.getIds(accounts);
-        Assert.equals(accounts.size(), accountIds.size());
-        for (Integer i = 0; i < accounts.size(); i++) {
-            Account account = accounts.get(i);
-            Id accountId = accountIds.get(i);
-            Assert.equals(account.Id, accountId);
+        List<Id> contactIds = CollectionUtil.getIds(contacts);
+        Assert.equals(contacts.size(), contactIds.size());
+        for (Integer i = 0; i < contacts.size(); i++) {
+            Contact contact = contacts.get(i);
+            Id contactId = contactIds.get(i);
+            Assert.equals(contact.Id, contactId);
         }
     }
 
     @IsTest
     static void testGetIdSet() {
-        List<Account> accounts = new List<Account>();
+        List<Contact> contacts = new List<Contact>();
         for (Integer i = 0; i < 5; i++) {
-            accounts.add(new Account(
-                Name = 'Account ' + (i + 1),
-                External_Account_Name__c = 'Account ' + (i + 1)
+            contacts.add(new Contact(
+                FirstName = 'Test',
+                LastName = 'User ' + (i + 1)
             ));
         }
-        insert accounts;
+        insert contacts;
 
         // Create a list with duplicate entries
-        List<Account> duplicateAccounts = new List<Account>();
-        duplicateAccounts.addAll(accounts);
-        duplicateAccounts.addAll(accounts);
+        List<Contact> duplicateContacts = new List<Contact>();
+        duplicateContacts.addAll(contacts);
+        duplicateContacts.addAll(contacts);
 
-        Set<Id> accountIds = CollectionUtil.getIdSet(duplicateAccounts);
-        Assert.equals(accounts.size(), accountIds.size());
-        for (Account account : accounts) {
-            Id accountId = account.Id;
-            Assert.isTrue(accountIds.contains(accountId));
-            accountIds.remove(accountId);
+        Set<Id> contactIds = CollectionUtil.getIdSet(duplicateContacts);
+        Assert.equals(contacts.size(), contactIds.size());
+        for (Contact contact : contacts) {
+            Id contactId = contact.Id;
+            Assert.isTrue(contactIds.contains(contactId));
+            contactIds.remove(contactId);
         }
-        Assert.isTrue(accountIds.isEmpty());
+        Assert.isTrue(contactIds.isEmpty());
     }
 
     @IsTest
@@ -425,30 +425,30 @@ private class CollectionUtilTest {
 
     @IsTest
     static void testMapByIdField() {
-        List<Account> accounts = new List<Account>();
+        List<Contact> managers = new List<Contact>();
         for (Integer i = 0; i < 2; i++) {
-            accounts.add(new Account(
-                Name = 'Account ' + (i + 1),
-                External_Account_Name__c = 'Account ' + (i + 1)
+            managers.add(new Contact(
+                FirstName = 'Manager',
+                LastName = 'User ' + (i + 1)
             ));
         }
-        insert accounts;
+        insert managers;
 
         List<Contact> contacts = new List<Contact>();
         for (Integer i = 0; i < 2; i++) {
             contacts.add(new Contact(
                 FirstName = 'Test',
                 LastName = 'User ' + (i + 1),
-                AccountId = accounts.get(i).Id
+                ReportsToId = managers.get(i).Id
             ));
         }
         insert contacts;
 
-        Map<Id, SObject> contactsByAccountId = CollectionUtil.mapByIdField(contacts, Contact.AccountId);
-        Assert.equals(contacts.size(), contactsByAccountId.size());
-        for (Id accountId : contactsByAccountId.keySet()) {
-            Contact contact = (Contact) contactsByAccountId.get(accountId);
-            Assert.equals(accountId, contact.AccountId);
+        Map<Id, SObject> contactsByManagerId = CollectionUtil.mapByIdField(contacts, Contact.ReportsToId);
+        Assert.equals(contacts.size(), contactsByManagerId.size());
+        for (Id managerId : contactsByManagerId.keySet()) {
+            Contact contact = (Contact) contactsByManagerId.get(managerId);
+            Assert.equals(managerId, contact.ReportsToId);
         }
     }
 
@@ -515,57 +515,57 @@ private class CollectionUtilTest {
 
     @IsTest
     static void testMapByFieldWithNullFieldValues() {
-        List<Account> accounts = new List<Account>();
+        List<Contact> contacts = new List<Contact>();
         for (Integer i = 0; i < 2; i++) {
-            accounts.add(new Account(
-                Name = 'Account ' + (i + 1),
-                AccountNumber = (i == 0) ? null : '12345',
-                External_Account_Name__c = 'Account ' + (i + 1)
+            contacts.add(new Contact(
+                FirstName = 'Test',
+                LastName = 'User ' + (i + 1),
+                Birthdate = (i == 0) ? null : System.today()
             ));
         }
-        insert accounts;
+        insert contacts;
 
-        Map<Object, SObject> accountsByAccountNumber = CollectionUtil.mapByField(accounts, Account.AccountNumber);
-        Assert.equals(accounts.size() - 1, accountsByAccountNumber.size());
-        for (Object accountNumber : accountsByAccountNumber.keySet()) {
-            Account account = (Account) accountsByAccountNumber.get(accountNumber);
-            Assert.isNotNull(account.AccountNumber);
-            Assert.equals(accountNumber, account.AccountNumber);
+        Map<Object, SObject> contactsByBirthDate = CollectionUtil.mapByField(contacts, Contact.Birthdate);
+        Assert.equals(contacts.size() - 1, contactsByBirthDate.size());
+        for (Object birthDate : contactsByBirthDate.keySet()) {
+            Contact contact = (Contact) contactsByBirthDate.get(birthDate);
+            Assert.isNotNull(contact.Birthdate);
+            Assert.equals(birthDate, contact.Birthdate);
         }
     }
 
     @IsTest
     static void testMultiMapByField() {
-        List<Account> accounts = new List<Account>();
+        List<Contact> managers = new List<Contact>();
         for (Integer i = 0; i < 2; i++) {
-            accounts.add(new Account(
-                Name = 'Account ' + (i + 1),
-                External_Account_Name__c = 'Account ' + (i + 1)
+            managers.add(new Contact(
+                FirstName = 'Manager',
+                LastName = 'User ' + (i + 1)
             ));
         }
-        insert accounts;
+        insert managers;
 
         List<Contact> contacts = new List<Contact>();
         for (Integer i = 0; i < 10; i++) {
-            Account account = accounts.get(Math.mod(i, 2));
+            Contact manager = managers.get(Math.mod(i, 2));
             contacts.add(new Contact(
                 FirstName = 'Test',
                 LastName = 'User ' + (i + 1),
-                AccountId = account.Id
+                ReportsToId = manager.Id
             ));
         }
         insert contacts;
 
-        MultiMap contactsByAccountId = CollectionUtil.multiMapByField(contacts, Contact.AccountId);
-        Assert.equals(accounts.size(), contactsByAccountId.keySet().size());
-        Assert.equals(contacts.size(), contactsByAccountId.values().size());
-        for (Object key : contactsByAccountId.keySet()) {
-            Id accountId = (Id) key;
-            List<Object> values = contactsByAccountId.getValues(accountId);
+        MultiMap contactsByManagerId = CollectionUtil.multiMapByField(contacts, Contact.ReportsToId);
+        Assert.equals(managers.size(), contactsByManagerId.keySet().size());
+        Assert.equals(contacts.size(), contactsByManagerId.values().size());
+        for (Object key : contactsByManagerId.keySet()) {
+            Id managerId = (Id) key;
+            List<Object> values = contactsByManagerId.getValues(managerId);
             Assert.equals(contacts.size() / 2, values.size());
             for (Object value : values) {
                 Contact contact = (Contact) value;
-                Assert.equals(accountId, contact.AccountId);
+                Assert.equals(managerId, contact.ReportsToId);
             }
         }
     }

--- a/test-src/classes/CollectionUtilTest.cls
+++ b/test-src/classes/CollectionUtilTest.cls
@@ -373,7 +373,8 @@ private class CollectionUtilTest {
         List<Account> accounts = new List<Account>();
         for (Integer i = 0; i < 5; i++) {
             accounts.add(new Account(
-                Name = 'Account ' + (i + 1)
+                Name = 'Account ' + (i + 1),
+                External_Account_Name__c = 'Account ' + (i + 1)
             ));
         }
         insert accounts;
@@ -392,7 +393,8 @@ private class CollectionUtilTest {
         List<Account> accounts = new List<Account>();
         for (Integer i = 0; i < 5; i++) {
             accounts.add(new Account(
-                Name = 'Account ' + (i + 1)
+                Name = 'Account ' + (i + 1),
+                External_Account_Name__c = 'Account ' + (i + 1)
             ));
         }
         insert accounts;
@@ -426,7 +428,8 @@ private class CollectionUtilTest {
         List<Account> accounts = new List<Account>();
         for (Integer i = 0; i < 2; i++) {
             accounts.add(new Account(
-                Name = 'Account ' + (i + 1)
+                Name = 'Account ' + (i + 1),
+                External_Account_Name__c = 'Account ' + (i + 1)
             ));
         }
         insert accounts;
@@ -516,7 +519,8 @@ private class CollectionUtilTest {
         for (Integer i = 0; i < 2; i++) {
             accounts.add(new Account(
                 Name = 'Account ' + (i + 1),
-                AccountNumber = (i == 0) ? null : '12345'
+                AccountNumber = (i == 0) ? null : '12345',
+                External_Account_Name__c = 'Account ' + (i + 1)
             ));
         }
         insert accounts;
@@ -535,7 +539,8 @@ private class CollectionUtilTest {
         List<Account> accounts = new List<Account>();
         for (Integer i = 0; i < 2; i++) {
             accounts.add(new Account(
-                Name = 'Account ' + (i + 1)
+                Name = 'Account ' + (i + 1),
+                External_Account_Name__c = 'Account ' + (i + 1)
             ));
         }
         insert accounts;


### PR DESCRIPTION
Changed CollectionUtilTest so that it no longer uses Account. This was causing issues when we were using it directly because of a unique custom field in our own metadata.
Made it possible to subclass PicklistEnum and TypeSafeEnum, primarily so that new intermediate base classes could be created that allow these enum types and their constants to be exported from managed packages.